### PR TITLE
fix view dropdown css

### DIFF
--- a/www/js/visEdit.js
+++ b/www/js/visEdit.js
@@ -2441,7 +2441,7 @@ vis = $.extend(true, vis, {
             tempList.val(this.activeView);
             tempList.selectmenu({
                 appendTo: "#view_select_list",
-                position: { my: "left top", at: "left bottom", of: "#view_select_list"},
+                position: { my: "left top", at: "left bottom", of: "#view_select_list", collision: "none" },
                 change: function (event, ui) {
                     var view = $(this).val();
                     that.changeView(view, view);
@@ -2450,9 +2450,13 @@ vis = $.extend(true, vis, {
                     tempList.selectmenu('destroy');
                     tempList.remove();
                 }
-            })
-                .selectmenu('open');
-
+            });
+            tempList.selectmenu('menuWidget').css('max-height', '400px')
+                .parent()
+                .css('height', 'calc(100vh - 135px)')
+                .css('overflow-x', 'hidden')
+                .css('overflow-y', 'scroll');
+            tempList.selectmenu('open');
         });
 
         $('#view_select_right').button({


### PR DESCRIPTION
Scrolling within dropdown menu should now behave similar to the original dropdown menu with many views and small window sizes.
Note: when using the mouse wheel it also seems to scroll within view_select_tabs_wrap at the same time, I have no idea how to fix this and why it happens.