### PR TITLE
vis-edit improvements

### DIFF
--- a/www/css/vis-editor.css
+++ b/www/css/vis-editor.css
@@ -840,7 +840,7 @@ td > .select_active_widget :nth-child(2) {
 }
 
 .view-select-menu {
-    height: calc(100% - 100px);
+    max-height: calc(100% - 100px);
     overflow-y: scroll;
     overflow-x: hidden;
 }
@@ -1086,4 +1086,5 @@ td > .select_active_widget :nth-child(2) {
 /*------------------------- context menu ------------------------------------*/
 .ui-menu-item {
     font-size: 12px !important;
+    text-align: left;
 }

--- a/www/js/vis.js
+++ b/www/js/vis.js
@@ -1068,7 +1068,10 @@ vis = {
     destroyWidget:      function (viewDiv, view, widget) {
         var $widget = $('#' + widget);
         if ($widget.length) {
-            var widgets = this.views[view].widgets[widget].data.members;
+            var widgets;
+            if (this.views[view].widgets[widget])
+                widgets = this.views[view].widgets[widget].data.members;
+            else return;
 
             if (widgets) {
                 for (var w = 0; w < widgets.length; w++) {

--- a/www/js/visEdit.js
+++ b/www/js/visEdit.js
@@ -2438,9 +2438,8 @@ vis = $.extend(true, vis, {
             text: false
         }).click(function () {
             var tempList = that.$selectView.clone();
-            tempList.val(this.activeView);
+            tempList.val(that.activeView);
             tempList.selectmenu({
-                appendTo: "#view_select_list",
                 position: { my: "left top", at: "left bottom", of: "#view_select_list", collision: "none" },
                 change: function (event, ui) {
                     var view = $(this).val();
@@ -2453,7 +2452,7 @@ vis = $.extend(true, vis, {
             });
             tempList.selectmenu('menuWidget').css('max-height', '400px')
                 .parent()
-                .css('height', 'calc(100vh - 135px)')
+                .css('max-height', 'calc(100vh - 135px)')
                 .css('overflow-x', 'hidden')
                 .css('overflow-y', 'scroll');
             tempList.selectmenu('open');

--- a/www/js/visEdit.js
+++ b/www/js/visEdit.js
@@ -5707,7 +5707,7 @@ vis = $.extend(true, vis, {
                 $('#' + widgets[w]).addClass('vis-widget-edit-locked').removeClass('ui-selectee ui-selected').unbind('click dblclick');
                 this.views[view].widgets[widgets[w]].data.locked = true;
             }
-            this.inspectWidgets(viewDiv, view, []);
+            this.inspectWidgets(viewDiv, view, widgets);
         }
     },
     unlockWidgets:          function (viewDiv, view, widgets) {
@@ -5726,6 +5726,7 @@ vis = $.extend(true, vis, {
                 }
                 this.bindWidgetClick(viewDiv, view, widgets[w]);
             }
+            this.inspectWidgets(viewDiv, view, widgets);
         }
     },
     bringTo:                function (viewDiv, view, widgets, isToFront) {
@@ -5817,7 +5818,19 @@ vis = $.extend(true, vis, {
             return isInside;
         });
 
-        if (!$list.length) return;
+        if (!$list.length) {
+            //reset z-index
+            for (var w = 0; w < widgets.length; w++) {
+                $wid = $('#' + widgets[w]);
+                zindex = undefined;
+                console.log('reset z-index of ' + widgets[w]);
+                $wid.css('z-index', zindex);
+                viewObj.widgets[widgets[w]].style['z-index'] = zindex;
+            }
+            this.inspectWidgets(viewDiv, view, true);
+            return;
+        }
+
         var that = this;
         // Move all widgets
         if (isToFront) {
@@ -5909,7 +5922,7 @@ vis = $.extend(true, vis, {
         return $viewDiv.find('.vis-widget').filter(function() {
             var offset = $(this).position();
             if (!$(this).length) return false;
-            if ($(this).hasClass('vis-widget-edit-locked')) return false;
+            //if ($(this).hasClass('vis-widget-edit-locked')) return false;
             var id = $(this).attr('id');
             if (viewDiv === id) return false;
 
@@ -6133,7 +6146,7 @@ vis = $.extend(true, vis, {
                         that.unlockWidgets(viewDiv, view, widgets);
                         break;
                     case 'export':
-                        that.exportWidgets(viewDiv, view, widgets);
+                        that.exportWidgets(widgets);
                         break;
                     case 'bringToBack':
                         that.bringTo(viewDiv, view, widgets, false);

--- a/www/js/visEdit.js
+++ b/www/js/visEdit.js
@@ -3602,7 +3602,7 @@ vis = $.extend(true, vis, {
             var views = this.getViewsOfWidget(id);
             var wids = id.split('_', 2);
             for (var i = 0; i < views.length; i++) {
-                this.delWidgetHelper(viewDiv, view, wids[0] + '_' + views[i], false);
+                this.delWidgetHelper(viewDiv, views[i], wids[0] + '_' + views[i], false);
             }
             this.inspectWidgets(viewDiv, view, []);
             return;
@@ -3620,7 +3620,7 @@ vis = $.extend(true, vis, {
             widgetDiv._customHandlers.onDelete(widgetDiv, id);
         }
         if (this.views[view].widgets[id] && this.views[view].widgets[id].data.members) {
-            var list = this.views[view].widgets[id].data.members;
+            var list = this.views[view].widgets[id].data.members.slice();
             for (var m = 0; m < list.length; m++) {
                 if (list[m] !== id) {
                     this.delWidgetHelper(viewDiv, view, list[m], isAll, id);
@@ -3633,7 +3633,21 @@ vis = $.extend(true, vis, {
         $('#' + id).remove();
         if (this.views[view].widgets[id] && this.views[view].widgets[id].grouped) {
             // find group
-            pos = this.views[view].widgets[groupId || viewDiv].data.members.indexOf(id);
+            var pos = -1;
+            if (!groupId && viewDiv == view) {
+                var widgets = this.views[view].widgets;
+                for (var w in widgets) {
+                    if (!widgets.hasOwnProperty(w)) continue;
+                    var members = this.views[view].widgets[w].data.members;
+                    if (members && ((pos = members.indexOf(id)) !== -1)) {
+                        groupId = w;
+                    }
+                }
+            }
+            else {
+                pos = this.views[view].widgets[groupId || viewDiv].data.members.indexOf(id);
+            }
+
             if (pos !== -1) this.views[view].widgets[groupId || viewDiv].data.members.splice(pos, 1);
         }
         if (view) delete this.views[view].widgets[id];
@@ -3973,31 +3987,46 @@ vis = $.extend(true, vis, {
         var widgetData = this.views[view].widgets[oldId];
         var obj = {
             tpl:    widgetData.tpl,
-            data:   widgetData.data,
+            data:   $.extend(true, {}, widgetData.data),
             style:  widgetData.style,
             wid:    newId,
             noSave: true
         };
-        if (widgetData.grouped) obj.grouped = true;
+        if (widgetData.grouped){
+            obj.grouped = true;
+            // get viewDiv
+            if (viewDiv == view) {
+                var widgets = this.views[view].widgets;
+                for (var w in widgets) {
+                    if (!widgets.hasOwnProperty(w)) continue;
+                    var members = this.views[view].widgets[w].data.members;
+                    var pos;
+                    if (members && ((pos = members.indexOf(oldId)) !== -1)) {
+                        viewDiv = w;
+                    }
+                }
+            }
+        }
 
         this.addWidget(viewDiv, view, obj, true);
 
-        if (widgetData.grouped) {
+        /*if (widgetData.grouped) {
             // rename in groups
             var widgets = this.views[view].widgets;
             for (var w in widgets) {
                 if (!widgets.hasOwnProperty(w)) continue;
                 var members = this.views[view].widgets[w].data.members;
                 var pos;
-                if (members && ((pos = members.indexOf(oldId)) !== -1)) {
-                    members[pos] = newId;
+                if (members && ((pos = members.indexOf(oldId)) !== -1) && members.indexOf(newId) === -1) {
+                    this.views[view].widgets[w].data.members[pos] = newId;
                 }
             }
-        }
-        if (viewDiv === this.activeView) this.updateSelectWidget(viewDiv, view, newId);
-        this.delWidgetHelper(oldId, false);
+        }*/
+        if (viewDiv === this.activeView) this.updateSelectWidget(view, view, newId);
+        delete this.views[view].widgets[oldId].data.members;
+        this.delWidgetHelper(viewDiv, view, oldId, false);
 
-        this.inspectWidgets(viewDiv, view, [newId]);
+        if (viewDiv === this.activeView) this.inspectWidgets(viewDiv, view, [newId]);
         this.save();
     },
     reRenderWidgetEdit:     function (viewDiv, view, wid) {
@@ -4049,6 +4078,11 @@ vis = $.extend(true, vis, {
             }
 
             if (view) {
+                //if widget is a group first sync widgets within this group
+                if (this.views[view].widgets[widgets[i]].data.members && this.views[view].widgets[widgets[i]].data.members.length) {
+                    this.syncWidgets(this.views[view].widgets[widgets[i]].data.members.slice(), views);
+                }
+
                 if (views === null) views = [];
 
                 var isFound = false;
@@ -4080,18 +4114,26 @@ vis = $.extend(true, vis, {
                     }
 
                     if (this.views[v_].widgets[wid + '_' + v_] !== undefined) {
-                        this.delWidgetHelper(wid + '_' + v_, false);
+                        this.delWidgetHelper(v_, v_, wid + '_' + v_, false);
                     }
 
                     if (isFound) {
+                        if (this.views[view].widgets[widgets[i]].data.members) {
+                            var data = $.extend(true, {}, this.views[view].widgets[widgets[i]].data);
+                            for (var j = 0; j < data.members.length; j++) {
+                                var _wids = data.members[j].split('_', 2);
+                                data.members[j] = _wids[0] + '_' + v_;
+                            }
+                        }
                         // Create
                         this.addWidget(this.views[v_] ? v_: this.getViewOfWidget(v_), v_, {
                             tpl:    this.views[view].widgets[widgets[i]].tpl, 
-                            data:   this.views[view].widgets[widgets[i]].data, 
+                            data:   data || this.views[view].widgets[widgets[i]].data,
                             style:  this.views[view].widgets[widgets[i]].style, 
                             wid:    wid + '_' + v_, 
                             view:   v_,
-                            noSave: true
+                            noSave: true,
+                            grouped:this.views[view].widgets[widgets[i]].grouped || false
                         }, true);
                     }
                 }
@@ -4100,9 +4142,9 @@ vis = $.extend(true, vis, {
                 if (views.length < 2 && (widgets[i].indexOf('_') !== -1)) {
                     // rename this widget from "wid_view" to "wid"
                     var _wids = widgets[i].split('_', 2);
-                    this.renameWidget(widgets[i], _wids[0]);
+                    this.renameWidget(view, view, widgets[i], _wids[0]);
                 } else if (views.length > 1 && (widgets[i].indexOf('_') === -1)) {
-                    this.renameWidget(widgets[i], widgets[i] + '_' + view);
+                    this.renameWidget(view, view, widgets[i], widgets[i] + '_' + view);
                 }
             }
         }


### PR DESCRIPTION
Improvements to view dropdowns:  
- click below will now close the dropdown  
- new dropdown menu will close on selection

Improvements to context menu:  
- fix export widgets via context menu
- to front and to back now reset widgets z-index if no other widget is in square  
- keep widgets selected after lock or unlock  
- allow selection of locked widgets via context menu / right click  (unlock in context menu is now reasonable)

Fix display of widgets and groups in multiple views:
- fix function calls
- fixes for groups