### PR TITLE
hide disabled layer after reconnect

### DIFF
--- a/www/js/conn.js
+++ b/www/js/conn.js
@@ -335,6 +335,10 @@ var servConn = {
                 that._isConnected = false;
                 if (that._connCallbacks.onConnChange) {
                     setTimeout(function () {
+                        //show server disconnect layer only when socket is not reconnected in the 5s timeout
+                        if (that._isConnected) {
+                            return
+                        }
                         var elem = document.getElementById('server-disconnect');
                         if (elem) elem.style.display = '';
                         that._connCallbacks.onConnChange(that._isConnected);

--- a/www/js/vis.js
+++ b/www/js/vis.js
@@ -3119,7 +3119,8 @@ function main($, onReady) {
                                 document.head.appendChild(script);
                             }
                         }
-
+                        // Hide old disabled layer
+                        $('.vis-view-disabled').hide();
                         // Read all states from server
                         console.debug('Request ' + (vis.editMode ? 'all' : vis.subscribing.active.length) + ' states.');
                         vis.conn.getStates(vis.editMode ? null : vis.subscribing.active, function (error, data) {


### PR DESCRIPTION
d28dafc Hide disabled layer when views are changed during disconnection and reconnect comes before the disabled layer can be hidden
this will fix issue #214 

3b86ce3 will prevent showing disconnect layer when during the 5s timeout the socket is already reconnected. This will lead to a never disappearing disconnect layer