### PR TITLE
add missing parameter to function call can.view

### DIFF
--- a/www/js/vis.js
+++ b/www/js/vis.js
@@ -1585,7 +1585,8 @@ var vis = {
                     val:     this.states.attr(widget.data.oid + '.val'),
                     data:    widgetData,
                     viewDiv: viewDiv,
-                    view:    view
+                    view:    view,
+                    style:   widget.style
                 });
                 if ($widget.length) {
                     if ($widget.parent().attr('id') !== $view.attr('id')) $widget.appendTo($view);
@@ -1598,7 +1599,8 @@ var vis = {
                 canWidget = can.view(widget.tpl, {
                     data:    widgetData,
                     viewDiv: viewDiv,
-                    view:    view
+                    view:    view,
+                    style:   widget.style
                 });
                 if ($widget.length) {
                     if ($widget.parent().attr('id') !== $view.attr('id')) $widget.appendTo($view);


### PR DESCRIPTION
function renderWidget: add parameter widget.style to the function call to can.view. the adapter wizard creates a function call with a 4. parameter named style, but this data never reaches the widget adapter browser code