### PR TITLE
Adapted error messages if no vis license was found

### DIFF
--- a/www/js/vis.js
+++ b/www/js/vis.js
@@ -99,16 +99,16 @@ if (typeof systemDictionary !== 'undefined') {
             "pl": "Nie znaleziono stron!",
             "zh-cn": "找不到页面！"},
         "No valid license found!": {
-            "en": "No valid license found!",
-            "de": "Keine gültige Lizenz gefunden!",
-            "ru": "Действительная лицензия не найдена!",
-            "pt": "Nenhuma licença válida encontrada!",
-            "nl": "Geen geldige licentie gevonden!",
-            "fr": "Aucune licence valide trouvée!",
-            "it": "Nessuna licenza valida trovata!",
-            "es": "No se encontró una licencia válida!",
-            "pl": "Nie znaleziono ważnej licencji!",
-            "zh-cn": "找不到有效的许可证！"
+            "en": "No valid vis license found! Please check vis instance.",
+            "de": "Keine gültige vis Lizenz gefunden! Bitte vis Instanz prüfen.",
+            "ru": "Действительная лицензия не найдена! Пожалуйста, проверьте пример.",
+            "pt": "Nenhuma licença válida encontrada! Por favor, verifique vis instance.",
+            "nl": "Geen geldige licentie gevonden! Controleer de vis-aankondiging.",
+            "fr": "Aucune licence valide trouvée ! Veuillez vérifier vis instance.",
+            "it": "Nessuna licenza valida trovata! Si prega di controllare di persona.",
+            "es": "No se encontró ninguna licencia válida! Por favor, compruebe la instancia de visita.",
+            "pl": "Nie znaleziono ważnej licencji! Proszę sprawdzić vis instance.",
+            "zh-cn": "找不到有效的许可证！请检查vis实例。"
         },
         'No Views found on Server': {
             'en': 'No Views found on Server',


### PR DESCRIPTION
Currently if no vis license is present, there is only a short message like "Keine gültige Lizenz gefunden!".

This message could be a bit more detailed. 
  - What license is missing? 
  - Also or beginners: Where can this problem be fixed?

I have extended the error message in all the 5 languages.
Please take a look into the change, if it is valuable for your project.

Best Regards
Tobias