### PR TITLE
support for material design widgets

### DIFF
--- a/www/widgets/basic.html
+++ b/www/widgets/basic.html
@@ -1139,7 +1139,7 @@
                     setInterval(function () {
                         if ($this.is(':visible')) {
                             var p = $this.parents(':hidden');
-                            if (!p.length || p[0].tagName === 'BODY') {
+                            if (!p.length || p[0].tagName === 'BODY' || p[0].id === 'materialdesign-vuetify-container') {
                                 $this.attr('src', src + (refreshWithNoQuery ? '' : ((src.indexOf('?') !== -1) ? '&' : '?') + '_refts=' + ((new Date()).getTime())));
                             }
                         }
@@ -1160,7 +1160,7 @@
                 setInterval(function () {
                     if ($this.is(':visible')) {
                         var p = $this.parents(':hidden');
-                        if (!p.length || p[0].tagName === 'BODY') {
+                        if (!p.length || p[0].tagName === 'BODY' || p[0].id === 'materialdesign-vuetify-container') {
                             $this.html(html);
                         }
                     }
@@ -1203,7 +1203,7 @@
                     setInterval(function () {
                         if ($this.is(':visible')) {
                             var p = $this.parents(':hidden');
-                            if (!p.length || p[0].tagName === 'BODY') {
+                            if (!p.length || p[0].tagName === 'BODY' || p[0].id === 'materialdesign-vuetify-container') {
                                 $this[0].src = src + (refreshWithNoQuery ? '' : ((src.indexOf('?') !== -1) ? '&' : '?') + '_refts=' + ((new Date()).getTime()));
                             }
                         }


### PR DESCRIPTION
Hi @GermanBluefox ,

since i implemented the vuetify api for the new sliders, i need a closing tag for the api, show here:
https://github.com/Scrounger/ioBroker.vis-materialdesign/blob/7859d055a4f980e7d478c590357ffdc432c179c7/widgets/materialdesign.html#L9

Now the Community figured out, that the refresh of the iframe, image and html not work anymore on chrome and safari browser. On Firefox this problme not occurs.

Reason is that Chrome and Safari give not back the 'body' as parent. So i implemented to also check the id of the closing tag describped above.

Could you please merge this and publish a new version on latest / stable ?