### PR TITLE
parse JSON for VIS bindings

### DIFF
--- a/www/js/vis.js
+++ b/www/js/vis.js
@@ -2374,7 +2374,12 @@ var vis = {
                                 if (value === undefined || value === null) {
                                     value = this.states.attr(oids[t].operations[k].arg[a].visOid);
                                 }
-                                string += 'var ' + oids[t].operations[k].arg[a].name + ' = "' + value + '";';
+                                try {
+                                    if (JSON.parse(value));
+                                    string += 'var ' + oids[t].operations[k].arg[a].name + ' = ' + value + ';';
+                                } catch(e) {
+                                    string += 'var ' + oids[t].operations[k].arg[a].name + ' = "' + value + '";';
+                                }
                             }
                             var formula = oids[t].operations[k].formula;
                             if (formula && formula.indexOf('widget.') !== -1) {


### PR DESCRIPTION
For JSON-bindings in VIS. Contribution from user "oweitman" in ioBroker#263 (comment)

`if (typeof value) { ... }` was not usable, I don't know the reason. With typeof-check, also Arrays would be recocnized as Objects and not declared as String.
Pull request to accelerate enhancement...