### PR TITLE
on pending getStates, try again instead of drop

### DIFF
--- a/www/js/conn.js
+++ b/www/js/conn.js
@@ -712,12 +712,14 @@ var servConn = {
             if (!this._checkConnection('getStates', arguments)) return;
 
             this.gettingStates = this.gettingStates || 0;
-            this.gettingStates++;
-            if (this.gettingStates > 1) {
-                // fix for slow devices
-                console.log('Trying to get empty list, because the whole list could not be loaded');
-                IDs = [];
+            if (this.gettingStates > 0) {
+                // fix for slow devices -> if getStates still in progress, wait and try again
+                console.log('Trying to get states again, because emitted getStates still pending');
+                setTimeout(() => this.getStates(IDs, callback), 50);
+                return;
             }
+
+            this.gettingStates++;
             var that = this;
             this._socket.emit('getStates', IDs, function (err, data) {
                 that.gettingStates--;


### PR DESCRIPTION
- because drop will result in missing states, which will only appear with a large delay and suggesting the user that widget does not work
- this fixes #179 (Slider Tabs) because it seems like on SliderTabs more than on getStates is fired (due to multiple widgets in one parent widget) and thus, there is one call still pending
- also, the logic was introduced for iPad 1 support which is now dropped anyways