### PR TITLE
Bug Fix Binding in JSON string

### DIFF
--- a/www/js/vis.js
+++ b/www/js/vis.js
@@ -2486,6 +2486,11 @@ var vis = {
                                 string += 'var widget = ' + JSON.stringify(widget) + ';';
                             }
                             string += 'return ' + oids[t].operations[k].formula + ';';
+                            
+                            if (string.indexOf('\\"') >= 0) {
+                                string = string.replace(/\\"/g, '"');
+                            }
+                            
                             //string += '}())';
                             try {
                                 value = new Function(string)();


### PR DESCRIPTION
To prevent the following error:
![grafik](https://user-images.githubusercontent.com/6370451/104448505-8e444f80-559d-11eb-9f51-d1fc88d7cd92.png)

caused by a binding in a json string. 

Problem here is that `mode === \"true\"` should be a `invalid escape sequence`, but the escape sequence is needed to parse a json string correctly.