### PR TITLE
Allow resources to be loaded as blob:

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -10,7 +10,7 @@
 
     <!-- cordova settings -->
     <meta http-equiv="Content-Security-Policy"
-          content="default-src 'self' * 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline' *; img-src 'self' 'unsafe-inline' * data:; media-src 'self' 'unsafe-inline' *; connect-src 'self' 'unsafe-eval' 'unsafe-inline' * ws: wss:; script-src 'self' 'unsafe-eval' 'unsafe-inline' *">
+          content="default-src 'self' * 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline' *; img-src 'self' 'unsafe-inline' * data: blob:; media-src 'self' 'unsafe-inline' *; connect-src 'self' 'unsafe-eval' 'unsafe-inline' * ws: wss: blob:; script-src 'self' 'unsafe-eval' 'unsafe-inline' *">
     <meta name="format-detection" content="telephone=no">
     <meta name="msapplication-tap-highlight" content="no">
 


### PR DESCRIPTION
I'm working on a new VIS Widget (https://github.com/Excodibur/ioBroker.vis-3dmodel) which uses ThreeJS-library. That library loads model-textures as blob, see [link](https://discourse.threejs.org/t/loading-model-via-gltfloader-with-0-118-throws-error/16741).

Is it possible to allow data to be loaded as "blob" in VIS CSP? Are there security concerns?
