### PR TITLE
local client variables

### DIFF
--- a/www/js/vis.js
+++ b/www/js/vis.js
@@ -324,6 +324,23 @@ var vis = {
     _setValue:          function (id, state, isJustCreated) {
         var that = this;
         var oldValue = this.states.attr(id + '.val');
+
+
+        //If Id start from "loc_", do not send changes to the server, we assume that it is a local variable of the client
+        if (id.indexOf("loc_")==0){
+	       that.states.attr(state);
+
+	       // Inform other widgets, that does not support canJS
+                for (var i = 0, len = that.onChangeCallbacks.length; i < len; i++) {
+                    try {
+                        that.onChangeCallbacks[i].callback(that.onChangeCallbacks[i].arg, id, state);
+                    } catch (e) {
+                        that.conn.logError('Error: can\'t update states object for ' + id + '(' + e + '): ' + JSON.stringify(e.stack));
+                    }
+                }
+	return;
+	}
+
         this.conn.setState(id, state[id + '.val'], function (err) {
             if (err) {
                 //state[id + '.val'] = oldValue;


### PR DESCRIPTION
sometimes local variables are needed on the client side, so that their changes do not affect other clients. It is suggested that the variable should be considered "local", its name should begin with the prefix " loc_"