### PR TITLE
Update visUtils.js

### DIFF
--- a/www/js/visUtils.js
+++ b/www/js/visUtils.js
@@ -62,7 +62,7 @@ function extractBinding(format) {
                 systemOid = systemOid.substring(0, systemOid.length - 3);
             }
             var operations = null;
-            var isEval = visOid.match(/[\d\w_.]+:\s?[-\d\w_.]+/) || (!visOid.length && parts.length > 0);//(visOid.indexOf(':') !== -1) && (visOid.indexOf('::') === -1);
+            var isEval = visOid.match(/[^\d\w_]+:\s?[-\d\w_.]+/) || (!visOid.length && parts.length > 0);//(visOid.indexOf(':') !== -1) && (visOid.indexOf('::') === -1);
 
             if (isEval) {
                 var xx = visOid.split(':', 2);
@@ -83,7 +83,7 @@ function extractBinding(format) {
             for (var u = 1; u < parts.length; u++) {
                 // eval construction
                 if (isEval) {
-                    if (parts[u].trim().match(/^[\d\w_.]+:\s?[-.\d\w_]+$/)) {//parts[u].indexOf(':') !== -1 && parts[u].indexOf('::') === -1) {
+                    if (parts[u].trim().match(/^[\d\w_]+:\s?[-.\d\w_]+$/)) {//parts[u].indexOf(':') !== -1 && parts[u].indexOf('::') === -1) {
                         var _systemOid = parts[u].trim();
                         var _visOid = _systemOid;
 


### PR DESCRIPTION
Betrifft https://github.com/ioBroker/ioBroker.vis/issues/212. Mit dieser Änderung funktionieren objekteIDs mit Doppelpunkt. Damit sollte mein Vorschlag von kürzlich umgesetzt sein. 

Bitte kritisch prüfen, könnte sein, dass damit etwas anderes kaputt ging. Die Möglichkeiten sind zahlreich und ich hab nur einen oberflächlichen Einblick in den Code, plus hab noch keinen guten Weg gefunden vis zu debuggen.