### PR TITLE
Added frame-src spec to content-security-policy header fixing

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,9 @@ Notice that these settings are valid only for reconnection and not for the first
     ### __WORK IN PROGRESS__
 -->
 
+### __WORK IN PROGRESS__
+* (jens-maus) Added frame-src spec to content-security-policy header fixing frame related content blocking issues (e.g. using KioskPro iOS app).
+
 ## Changelog
 ### 1.4.4 (2021-08-31)
 * (jobe451) Allowed to have ":" in the binding object IDs

--- a/www/index.html
+++ b/www/index.html
@@ -10,7 +10,7 @@
 
     <!-- cordova settings -->
     <meta http-equiv="Content-Security-Policy"
-          content="default-src 'self' * 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline' *; img-src 'self' 'unsafe-inline' * data:; media-src 'self' 'unsafe-inline' *; connect-src 'self' 'unsafe-eval' 'unsafe-inline' * ws: wss:; script-src 'self' 'unsafe-eval' 'unsafe-inline' *">
+          content="default-src 'self' * 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline' *; img-src 'self' 'unsafe-inline' * data:; media-src 'self' 'unsafe-inline' *; connect-src 'self' 'unsafe-eval' 'unsafe-inline' * ws: wss:; script-src 'self' 'unsafe-eval' 'unsafe-inline' *; frame-src 'self' 'unsafe-eval' 'unsafe-inline' * data: kioskpro:">
     <meta name="format-detection" content="telephone=no">
     <meta name="msapplication-tap-highlight" content="no">
 


### PR DESCRIPTION
This PR adds `frame-src 'self' 'unsafe-eval' 'unsafe-inline' * data: kioskpro:` to the default `content-security-policy` meta header of VIS. This fixes content blocking issues where a browser rejects execution of certain content if provided by external sources. This is indeed a very prominent issues which especially comes up if, e.g., the [KioskPro](https://www.kioskgroup.com/pages/kiosk-pro-software) iOS app is used where its [Javascript API](https://support.kioskgroup.com/article/1124-api-best-practices) can be used to query certain device related information (battery level, memory consumption, etc.). Thus, the added `kioskpro:` path at the end of the altered `frame-src` content of the CSP meta header. Overall, this `frame-src` addition should also fix similar issues other ioBroker vis users also encountered (see https://forum.iobroker.net/topic/25533/iframe-wird-nicht-angezeigt/24?_=1632476907388&lang=de).
