### PR TITLE
fix jumping widgets on state-update if grouped

### DIFF
--- a/www/js/vis.js
+++ b/www/js/vis.js
@@ -1090,7 +1090,7 @@ var vis = {
         viewDiv = viewDiv || this.activeViewDiv;
 
         this.destroyWidget(viewDiv, view, widget);
-        this.renderWidget(viewDiv, view, widget, !this.views[viewDiv] && viewDiv !== widget ? viewDiv : null);
+        this.renderWidget(viewDiv, view, widget, !this.views[viewDiv] && viewDiv !== widget ? viewDiv : vis.views[view].widgets[widget].groupid ? vis.views[view].widgets[widget].groupid : null);
 
         updateContainers && this.updateContainers(viewDiv, view);
     },

--- a/www/js/visEdit.js
+++ b/www/js/visEdit.js
@@ -6792,6 +6792,7 @@ vis = $.extend(true, vis, {
 
             $('#' + widgets[w]).remove();
             this.views[view].widgets[widgets[w]].grouped = true;
+            this.views[view].widgets[widgets[w]].groupid = groupId;
         }
         this.views[view].widgets[groupId] = {
             tpl: '_tplGroup',
@@ -6821,6 +6822,7 @@ vis = $.extend(true, vis, {
             for (w = 0; w < widgets.length; w++) {
                 if (!this.views[view].widgets[widgets[w]]) continue;
                 if (this.views[view].widgets[widgets[w]].grouped !== undefined) delete this.views[view].widgets[widgets[w]].grouped;
+                if (this.views[view].widgets[widgets[w]].groupid !== undefined) delete this.views[view].widgets[widgets[w]].groupid;
                 var wRect = this.editWidgetsRect(viewDiv, view, widgets[w]);
                 this.views[view].widgets[widgets[w]].style.top    = wRect.top    + 'px';
                 this.views[view].widgets[widgets[w]].style.left   = wRect.left   + 'px';


### PR DESCRIPTION
fixing https://github.com/ioBroker/ioBroker.vis/issues/432
i implement my proposed solution Nr1 

add a new property with groupid for each grouped widget (including deleting on ungroup)
and check for grouped widget oin renderWidget

