### PR TITLE
Replace groupAttr recursively

### DIFF
--- a/www/js/vis.js
+++ b/www/js/vis.js
@@ -40,6 +40,20 @@
 /* jshint -W097 */// jshint strict:false
 'use strict';
 
+function replaceGroupAttr(inputStr, groupAttrList) {
+    let newString = inputStr
+    let match = false
+    let ms = inputStr.match(/(groupAttr\d+)+?/g)
+    if (ms) {
+        match = true
+        ms.forEach(function (m){
+            newString = newString.replace(/groupAttr(\d+)/, groupAttrList[m]);
+        });
+        console.log("Replaced " + inputStr + " with " + newString + " (based on " + ms + ")")
+    }
+    return [match, newString]
+}
+
 if (typeof systemDictionary !== 'undefined') {
     $.extend(systemDictionary, {
         'No connection to Server':  {'en': 'No connection to Server',   'de': 'Keine Verbindung zum Server', 'ru': 'Нет соединения с сервером',
@@ -1618,9 +1632,11 @@ var vis = {
             var aCount = parseInt(this.views[view].widgets[groupId].data.attrCount, 10);
             if (aCount) {
                 $.map(widget.data, function(val, key) {
-                    var m;
-                    if (typeof val === 'string' && (m = val.match(/^groupAttr(\d+)$/))) {
-                        widget.data[key] = that.views[view].widgets[groupId].data[m[0]] || '';
+                    if (typeof val === 'string') {
+                        const [doesMatch, newString] = replaceGroupAttr(val, that.views[view].widgets[groupId].data)
+                        if(doesMatch) {
+                            widget.data[key] = newString || '';
+                        }
                     }
                 });
             }

--- a/www/js/visUtils.js
+++ b/www/js/visUtils.js
@@ -14,6 +14,20 @@
  * (Free for non-commercial use).
  */
 
+function replaceGroupAttr(inputStr, groupAttrList) {
+    let newString = inputStr
+    let match = false
+    let ms = inputStr.match(/(groupAttr\d+)+?/g)
+    if (ms) {
+        match = true
+        ms.forEach(function (m){
+            newString = newString.replace(/groupAttr(\d+)/, groupAttrList[m]);
+        });
+        console.log("Replaced " + inputStr + " with " + newString + " (based on " + ms + ")")
+    }
+    return [match, newString]
+}
+
 function getWidgetGroup(views, view, widget) {
     var widgets = views[view].widgets;
     var members;
@@ -425,9 +439,10 @@ function getUsedObjectIDs(views, isByViews) {
                         // Visibility binding
                         if (attr === 'visibility-oid' && data['visibility-oid']) {
                             var vid = data['visibility-oid'];
-                            if (vid.match(/^groupAttr(\d+)$/)) {
-                                var vgroup = getWidgetGroup(views, view, id);
-                                if (vgroup) vid = views[view].widgets[vgroup].data[vid];
+                            var vgroup = getWidgetGroup(views, view, id);
+                            if (vgroup) {
+                                const [doesMatch, newString] = replaceGroupAttr(vid, views[view].widgets[vgroup].data)
+                                if (doesMatch) vid = newString;
                             }
 
                             if (!visibility[vid]) visibility[vid] = [];
@@ -437,9 +452,10 @@ function getUsedObjectIDs(views, isByViews) {
                         // Signal binding
                         if (attr.match(/^signals-oid-/) && data[attr]) {
                             var sid = data[attr];
-                            if (sid.match(/^groupAttr(\d+)$/)) {
-                                var group = getWidgetGroup(views, view, id);
-                                if (group) sid = views[view].widgets[group].data[sid];
+                            var group = getWidgetGroup(views, view, id);
+                            if(group) {
+                                const [doesMatch, newString] = replaceGroupAttr(sid, views[view].widgets[group].data)
+                                if (doesMatch) sid = newString;
                             }
 
                             if (!signals[sid]) signals[sid] = [];
@@ -451,9 +467,10 @@ function getUsedObjectIDs(views, isByViews) {
                         }
                         if (attr === 'lc-oid') {
                             var lcsid = data[attr];
-                            if (lcsid.match(/^groupAttr(\d+)$/)) {
-                                var ggroup = getWidgetGroup(views, view, id);
-                                if (ggroup) lcsid = views[view].widgets[ggroup].data[lcsid];
+                            var ggroup = getWidgetGroup(views, view, id);
+                            if(ggroup) {
+                                const [doesMatch, newString] = replaceGroupAttr(lcsid, views[view].widgets[ggroup].data)
+                                if (doesMatch) lcsid = newString;
                             }
 
                             if (!lastChanges[lcsid]) lastChanges[lcsid] = [];


### PR DESCRIPTION
# Description
This PR is an approach of replacing groupAttrs recursively. This allows to use constructs in groups like `some_object.groupAttr1.sub_component` or even more complex once like `some_object.groupAttr1.intermediate_stuff.groupAttr2.sub_component`.

This addresses request like the following:

- https://forum.iobroker.net/topic/15880/nutzung-von-attributen-in-gruppierungen
- https://forum.iobroker.net/topic/31402/vis-groupattr-einen-ordner-von-objekten-%C3%BCbergeben

Imo this would be a great enhancement for the use of groups when generating a visualisation.

# Open Points

## Duplicated code

The function `replaceGroupAttr` is duplicated in the files `www/js/vis.js` and `www/js/visUtils.js`. I don't know where you would put such pieces of code to share. Please let me know and I will fix it.

## Replaced groupAttr not evaluated on first loading of vis 

I made a test on a local setup where I used this approach to display the position of a window shutter. There is a problem when the vis page is first loaded, it looks like the position is not evaluated. When the position of the window shutter is changed the data gets interpreted correctly.   
It's also possible that this has nothing to do with the changes from this PR (but I doubt it, which would mean the PR is not perfect).

The edit vis page is always showing the correct things (position is evaluated instantly).

Maybe some experts here have an idea what the problem of this could be.

Let me know if I shall provide more information around this test.

# New to contributing to ioBroker.vis

I am new to contributing to ioBroker.vis so please guide me where I am not following your rules.