### PR TITLE
add groupid to import widgets and group edit dialog

### DIFF
--- a/www/js/visEdit.js
+++ b/www/js/visEdit.js
@@ -3586,6 +3586,12 @@ vis = $.extend(true, vis, {
                             mapping[importObject[widget].groupName] = widgetId;
                         }
 
+                        if (importObject[widget].tpl === '_tplGroup') {
+                            for (var d = 0; d < importObject[widget].data.members.length; d++) {
+                                vis.views[view].widgets[importObject[widget].data.members[d]].groupid=widgetId;
+                            }                                
+                        }
+
                         // (tpl, data, style, wid, view, noSave, noAnimate)
                         if (!importObject[widget].grouped) widgets.push(widgetId);
                     }

--- a/www/js/visEdit.js
+++ b/www/js/visEdit.js
@@ -3982,7 +3982,10 @@ vis = $.extend(true, vis, {
             widgetSet: options.tpl === '_tplGroup' ? null : ($tpl ? $tpl.attr('data-vis-set') : undefined)
         };
 
-        if (options.grouped || viewDiv !== view) this.views[view].widgets[widgetId].grouped = true;
+        if (options.grouped || viewDiv !== view) {
+            this.views[view].widgets[widgetId].grouped = true;
+            this.views[view].widgets[widgetId].groupid = viewDiv;
+        }
         // if group edit
         if (viewDiv !== view) {
             this.views[view].widgets[viewDiv].data.members.push(widgetId);


### PR DESCRIPTION
commit 1
when grouped widgets are imported, they lose the groupid property.
introduced the groupid to assign a widget to a group. the attribute simplifies the updating of data and prevents the widget from "jumping".

this pull request adds the groupid to the import

commit 2
add groupid to the group edit dialog
