### PR TITLE
Update Content-Security-Policy to support HLS

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -10,7 +10,7 @@
 
     <!-- cordova settings -->
     <meta http-equiv="Content-Security-Policy"
-          content="default-src 'self' * 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline' *; img-src 'self' 'unsafe-inline' * data:; media-src 'self' 'unsafe-inline' *; connect-src 'self' 'unsafe-eval' 'unsafe-inline' * ws: wss:; script-src 'self' 'unsafe-eval' 'unsafe-inline' *; frame-src 'self' 'unsafe-eval' 'unsafe-inline' * data: kioskpro:">
+          content="default-src 'self' * 'unsafe-eval' 'unsafe-inline' blob:; style-src 'self' 'unsafe-inline' *; img-src 'self' 'unsafe-inline' * data:; media-src 'self' 'unsafe-inline' blob: *; connect-src 'self' 'unsafe-eval' 'unsafe-inline' * ws: wss:; script-src 'self' 'unsafe-eval' 'unsafe-inline' blob: *; frame-src 'self' 'unsafe-eval' 'unsafe-inline' * data: kioskpro:">
     <meta name="format-detection" content="telephone=no">
     <meta name="msapplication-tap-highlight" content="no">
 


### PR DESCRIPTION
Update Content-Security-Policy to support HLS streams.

Usecase:
I transform rtsp streams to hls with https://github.com/aler9/rtsp-simple-server.
Not to run in a Content-Security-Policy block, i need to allow 'blob:'