### PR TITLE
Datenpunkte mit Sonderzeichen in vis in bindings

### DIFF
--- a/www/js/visUtils.js
+++ b/www/js/visUtils.js
@@ -123,7 +123,7 @@ function extractBinding(format) {
             for (var u = 1; u < parts.length; u++) {
                 // eval construction
                 if (isEval) {
-                    if (parts[u].trim().match(/^[\d\w_]+:\s?[-.\d\w_]+$/)) {//parts[u].indexOf(':') !== -1 && parts[u].indexOf('::') === -1) {
+                    if (parts[u].trim().match(/^[\d\w_]+:\s?[._\-\/ :!#$%&()+=@^{}|~\p{Ll}\p{Lu}\p{Nd}]+$/u)) {
                         var _systemOid = parts[u].trim();
                         var _visOid = _systemOid;
 


### PR DESCRIPTION
2. und 3. Datenpunkte innerhalb eines bindings, welche Sonderzeichen enthalten (bspw öäü oder #) konnten in vis nicht für Berechnungen in bindings verwendet werden, da sie durch das regex nicht erkannt werden konnten. das regex wurde aus dem js-controller entnommen, der dort auf gültige datenpunktbezeichnungen prüft.

https://forum.iobroker.net/topic/69004/rechnen-im-html-widget-geht-nicht-mehr/19?page=1

ich habe versucht einen PR für vis2 zu eröffnen, lande aber wieder hier. ich bin verwirrt