### PR TITLE
Creation of js/config.js / fixed. Fixes first time installation with 1.5.1 

### DIFF
--- a/main.js
+++ b/main.js
@@ -157,7 +157,12 @@ async function generatePages() {
     let changed = !!syncWidgetSets(false);
 
     // upload config.js
-    let data = await adapter.readFileAsync(adapterName, 'js/config.js');
+    let data;
+    try {
+        data = await adapter.readFileAsync(adapterName, 'js/config.js');
+    } catch (_e) {
+        //
+    }
     if (typeof data === 'object') {
         data = data.file;
     }


### PR DESCRIPTION
When installing 1.5.1 (= version without license check) at a system without any prio vis installation, the installation crashes when trying to read js&config.js at https://github.com/ioBroker/ioBroker.vis/blob/e87d80d474a366f6b9a6813d5dec30c77919a9cd/main.js#L160 as the file does not yet exist.

Version up to 1.4.16 create this file during license check as license data does not exist in the case of the first installation:
see https://github.com/ioBroker/ioBroker.vis/blob/442157dde1080199f9079c7d7314d8480535fcc0/main.js#L267

Problem has been reported by issue https://github.com/ioBroker/ioBroker.vis/issues/805

Solution implemented is to catch read error for non existing files.

Please check whether some other still needed information within js/config.js get lost due to removal of license checks.
 